### PR TITLE
Added to_snake_case helper method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,10 +156,9 @@ fn to_snake_case<S: AsRef<str>>(ident: &S) -> String {
     for (i, c) in ident.as_ref().chars().enumerate() {
         if i > 0 && c.is_uppercase() {
             snake_case.push('_');
-            snake_case.push(c.to_lowercase().next().unwrap());
-        } else {
-            snake_case.push(c.to_lowercase().next().unwrap());
         }
+
+        snake_case.push(c.to_lowercase().next().unwrap());
     }
 
     snake_case

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ is for when a method is called for the wrong variant and needs to `panic!`.
 
 `EnumIsA` is much simpler than the previous; it simply adds `is_XXX`
 methods returning a boolean for whether the variant matches or not. Similar
-to `EnumGetters`, the name is converted to lowercase and does **not** 
+to `EnumGetters`, the name is converted to lowercase and does **not**
 convert to snake\_case.
 
 # License
@@ -150,6 +150,21 @@ pub fn enum_is_a(input: TokenStream) -> TokenStream {
     gen.parse().unwrap()
 }
 
+fn to_snake_case(ident: &Ident) -> String {
+    let mut snake_case = String::new();
+
+    for (i, c) in ident.as_ref().chars().enumerate() {
+        if i > 0 && c.is_uppercase() {
+            snake_case.push('_');
+            snake_case.push(c.to_lowercase().next().unwrap());
+        } else {
+            snake_case.push(c.to_lowercase().next().unwrap());
+        }
+    }
+
+    snake_case
+}
+
 fn impl_enum_getters(ast: &DeriveInput) -> quote::Tokens {
     let ref name = ast.ident;
 
@@ -165,27 +180,27 @@ fn impl_enum_getters(ast: &DeriveInput) -> quote::Tokens {
                 .filter(|v| !COPYABLE.contains(&v.data.fields()[0].ty))
         };
     }
-        
+
 
     let variant_names = getter_filter!()
         .map(|v| v.ident.clone())
         .collect::<Vec<Ident>>();
 
     let function_names = getter_filter!()
-        .map(|v| v.ident.to_string().to_lowercase().into())
+        .map(|v| to_snake_case(&v.ident).into())
         .collect::<Vec<Ident>>();
 
     let function_name_strs = getter_filter!()
         .map(|v| v.ident.to_string().to_lowercase())
         .collect::<Vec<String>>();
 
-    let variant_types = getter_filter!() 
+    let variant_types = getter_filter!()
         .map(|v| &v.data.fields()[0].ty)
         .map(|ty| Ty::Rptr(None, Box::new(MutTy { ty: ty.clone(), mutability: Mutability::Immutable })))
         .collect::<Vec<Ty>>();
 
     let getter_names = vec!(name.clone(); variant_types.len());
-    
+
     quote! {
         #[allow(dead_code)]
         impl #name {
@@ -217,27 +232,27 @@ fn impl_copyable_enum_getters(ast: &DeriveInput) -> quote::Tokens {
                 .filter(|v| COPYABLE.contains(&v.data.fields()[0].ty))
         };
     }
-        
+
 
     let variant_names = getter_filter!()
         .map(|v| v.ident.clone())
         .collect::<Vec<Ident>>();
 
     let function_names = getter_filter!()
-        .map(|v| v.ident.to_string().to_lowercase().into())
+        .map(|v| to_snake_case(&v.ident).into())
         .collect::<Vec<Ident>>();
 
     let function_name_strs = getter_filter!()
         .map(|v| v.ident.to_string().to_lowercase())
         .collect::<Vec<String>>();
 
-    let variant_types = getter_filter!() 
+    let variant_types = getter_filter!()
         .map(|v| &v.data.fields()[0].ty)
         .map(|ty| ty.clone())
         .collect::<Vec<Ty>>();
 
     let getter_names = vec!(name.clone(); variant_types.len());
-    
+
     quote! {
         #[allow(dead_code)]
         impl #name {
@@ -273,7 +288,7 @@ fn impl_enum_is_a(ast: &DeriveInput) -> quote::Tokens {
         .collect::<Vec<Ident>>();
 
     let function_names = is_a_filter!()
-        .map(|v| format!("is_{}", v.ident.to_string().to_lowercase()).into())
+        .map(|v| format!("is_{}", to_snake_case(&v.ident)).into())
         .collect::<Vec<Ident>>();
 
     let variant_counts = is_a_filter!()
@@ -281,7 +296,7 @@ fn impl_enum_is_a(ast: &DeriveInput) -> quote::Tokens {
         .collect::<Vec<_>>();
 
     let getter_names = vec!(name.clone(); variant_names.len());
-    
+
     quote! {
         #[allow(dead_code)]
         impl #name {
@@ -316,11 +331,11 @@ fn impl_unit_enum_is_a(ast: &DeriveInput) -> quote::Tokens {
         .collect::<Vec<Ident>>();
 
     let function_names = is_a_filter!()
-        .map(|v| format!("is_{}", v.ident.to_string().to_lowercase()).into())
+        .map(|v| format!("is_{}", to_snake_case(&v.ident)).into())
         .collect::<Vec<Ident>>();
 
     let getter_names = vec!(name.clone(); variant_names.len());
-    
+
     quote! {
         #[allow(dead_code)]
         impl #name {
@@ -355,7 +370,7 @@ fn impl_struct_enum_is_a(ast: &DeriveInput) -> quote::Tokens {
         .collect::<Vec<Ident>>();
 
     let function_names = is_a_filter!()
-        .map(|v| format!("is_{}", v.ident.to_string().to_lowercase()).into())
+        .map(|v| format!("is_{}", to_snake_case(&v.ident)).into())
         .collect::<Vec<Ident>>();
 
     let variant_field_names = is_a_filter!()
@@ -367,7 +382,7 @@ fn impl_struct_enum_is_a(ast: &DeriveInput) -> quote::Tokens {
         .collect::<Vec<_>>();
 
     let getter_names = vec!(name.clone(); variant_names.len());
-    
+
     quote! {
         #[allow(dead_code)]
         impl #name {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@ pub fn enum_is_a(input: TokenStream) -> TokenStream {
     gen.parse().unwrap()
 }
 
-fn to_snake_case(ident: &Ident) -> String {
+fn to_snake_case<S: AsRef<str>>(ident: &S) -> String {
     let mut snake_case = String::new();
 
     for (i, c) in ident.as_ref().chars().enumerate() {

--- a/tests/test_getters.rs
+++ b/tests/test_getters.rs
@@ -29,8 +29,8 @@ fn test_getter_names() {
 
     let first = MyEnum::FooBar(true);
     let second = MyEnum::BarBaz("there's nothing that a hundred men or more could ever do".to_string());
-    assert_eq!(first.foobar(), true);
-    assert_eq!(second.barbaz(), "there's nothing that a hundred men or more could ever do");
+    assert_eq!(first.foo_bar(), true);
+    assert_eq!(second.bar_baz(), "there's nothing that a hundred men or more could ever do");
 }
 
 #[test]
@@ -56,7 +56,7 @@ fn test_getter_structs() {
     let first = MyEnum::FooBar(true);
     let second = MyEnum::BarBaz("there's nothing that a hundred men or more could ever do".to_string());
     let third = MyEnum::SomeStruct { foo: 42 };
-    assert_eq!(first.foobar(), true);
-    assert_eq!(second.barbaz(), "there's nothing that a hundred men or more could ever do");
+    assert_eq!(first.foo_bar(), true);
+    assert_eq!(second.bar_baz(), "there's nothing that a hundred men or more could ever do");
     assert_eq!(third.somestruct(), 42);
 }

--- a/tests/test_is_a.rs
+++ b/tests/test_is_a.rs
@@ -21,8 +21,8 @@ fn test_is_a() {
     assert!(first.is_foo());
     assert!(second.is_bar());
     assert!(third.is_baz());
-    assert!(fourth.is_structtype());
-    assert!(fifth.is_biggerstructtype());
+    assert!(fourth.is_struct_type());
+    assert!(fifth.is_bigger_struct_type());
 }
 
 #[test]
@@ -38,8 +38,8 @@ fn test_is_a_names() {
     let second = MyEnum::BarBaz(false, -3);
     let third = MyEnum::Baz("cheers only whispers of some quiet conversation".to_string());
 
-    assert!(first.is_foobar());
-    assert!(second.is_barbaz());
+    assert!(first.is_foo_bar());
+    assert!(second.is_bar_baz());
     assert!(third.is_baz());
 }
 


### PR DESCRIPTION
Hi! You've got a neat crate going on here. Hope you continue to improve it!

1) Sorry my editor stripped a bunch of whitespace. If this bothers you I can add it back in
2) test_getter_structs L61 is still `third.somestruct()` Maybe you could point me in the right direction for fixing that one?
3) Note my hilariously ugly (but working) first attempt at being clever with iterators:
```rust
fn to_snake_case(ident: &Ident) -> String {
    fn add_underscore(size_char: (usize, char)) -> String {
        let (i, c) = size_char;

        if i > 0 && c.is_uppercase() {
            "_".chars()
               .zip(c.to_lowercase())
               .map(|(c1, c2)| format!("{}{}", c1, c2))
               .next()
               .unwrap()
        } else {
            c.to_lowercase()
             .next()
             .unwrap()
             .to_string()
        }
    };

    ident.as_ref()
         .chars()
         .enumerate()
         .map(add_underscore)
         .collect::<String>()
         .into()
}
```

Fixed #1 